### PR TITLE
jekyllをローカルでbuildしたとき生成されるディレクトリをgitignoreに追加した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .commit
+_site
+.bundle
+.jekyll-cache


### PR DESCRIPTION
jekyllでローカルbuildするとディレクトリが生成されるのでそれらをgitignoreに追加した