### PR TITLE
npm scriptsを使うようにした

### DIFF
--- a/.github/workflows/add-a-new-book.yml
+++ b/.github/workflows/add-a-new-book.yml
@@ -13,11 +13,8 @@ jobs:
           echo "${{ github.event.issue.body }}" | while read isbn; do
             bash add_book.bash $isbn
           done
-      - name: Commit a change
-        run: |
-          git config user.name 'jinpei0908'
-          git config user.email 'jinpei0908@gmail.com'
-          git commit -am '本追加'
+      - name: Prettier and build
+        run: npm run prettier && npm run build
       - name: Create Pull Request if `本追加` in issue title
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
git commitだと`npm run build` が動いてなさそうだったのでworkflow上で直接`npm scripts`を動かすようにした。