### PR TITLE
書誌データ利用ルールについて書いた

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,12 @@
 <body>
     <div class="container">
         <div id="root"></div>
+        <div>
+            <p>このページで表示している書誌データは国立国会図書館書誌データを使用しており、必要に応じて加工・修正を行ってます。著作権の取り扱いについて問題があれば、対応しますので
+                <a href="https://github.com/jinpei0908/fe-book/issues">こちらのページ</a>よりissueを立ててお知らせください。
+            </p>
+            <p>書誌データ利用ルールについて詳しくは<a href="https://www.ndl.go.jp/jp/use/metadata/index.html">こちらのページ</a>より確認してください。</p>
+        </div>
 
         <script src="https://unpkg.com/react@17/umd/react.production.min.js" crossorigin></script>
         <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js" crossorigin></script>


### PR DESCRIPTION
書誌データ利用ルールより、データ出典元を明記する必要があるので追加した。
https://www.ndl.go.jp/jp/use/metadata/index.html